### PR TITLE
Fix Spanish September name

### DIFF
--- a/src/harbours_tide_data.py
+++ b/src/harbours_tide_data.py
@@ -46,7 +46,7 @@ CHROME_OPTIONS.add_argument("--window-size=1920x1080")        # Set window size 
 CSV_PATH = 'src/res/shn_data/'
 MONTH_NAMES = {
         '1': 'Enero', '2': 'Febrero', '3': 'Marzo', '4': 'Abril', '5': 'Mayo',
-        '6': 'Junio', '7': 'Julio', '8': 'Agosto', '9': 'Setiembre',
+        '6': 'Junio', '7': 'Julio', '8': 'Agosto', '9': 'Septiembre',
         '10': 'Octubre', '11': 'Noviembre', '12': 'Diciembre'
     }
 

--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,7 @@ CSV_PATH = './res/shn_data'
 
 MONTH_NAMES = {
     '1': 'Enero', '2': 'Febrero', '3': 'Marzo', '4': 'Abril', '5': 'Mayo',
-    '6': 'Junio', '7': 'Julio', '8': 'Agosto', '9': 'Setiembre',
+    '6': 'Junio', '7': 'Julio', '8': 'Agosto', '9': 'Septiembre',
     '10': 'Octubre', '11': 'Noviembre', '12': 'Diciembre'
 }
 


### PR DESCRIPTION
## Summary
- correct Spanish month name in tide dictionaries

## Testing
- `python -m py_compile src/main.py src/harbours_tide_data.py`


------
https://chatgpt.com/codex/tasks/task_e_688439da88e4832f9c03da07ebbd4bcd