### PR TITLE
Fix month range in tide data fetch

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -192,7 +192,7 @@ def good_conditions():
     for year in range(min_year, max_year + 1):
         start_month = min_month if year == min_year else 1
         end_month = max_month if year == max_year else 12
-        for month in range(min_month, max_month + 1):
+        for month in range(start_month, end_month + 1):
             tide_df = generate_tide_table(str(year), str(month), harbour)
             all_tide_df = pd.concat([all_tide_df, tide_df])
 


### PR DESCRIPTION
## Summary
- correct months loop when generating tide tables

## Testing
- `python -m py_compile src/main.py src/harbours_tide_data.py`


------
https://chatgpt.com/codex/tasks/task_e_688438a6eb30832fb7ec582f04cb1387